### PR TITLE
Fixed: summary work in cypher query, but with zeroes for unfound ranks

### DIFF
--- a/app/graph.py
+++ b/app/graph.py
@@ -228,24 +228,28 @@ class Graph(object):
         if not issue:
             return False, "issue <{0}> does not exist".format(issue_id), []
         query = """
-            MATCH (u:User)-[r:RANKS]-(v:`{0}`),
-            (v)<-[:HAS]-(i:Issue)
+            MATCH (v:`{0}`)<-[:HAS]-(i:Issue)
             WHERE i.node_id = {{issue_id}}
-            RETURN
+            WITH v, [-2, -1, 0, 1, 2] as coll UNWIND coll AS rank
+            OPTIONAL MATCH (u:User)-[r:RANKS]->(v)
+            WHERE r.rank = rank
+            WITH
                 v.node_id AS node_id,
                 v.name AS name,
-                r.rank AS rank,
+                rank,
                 count(u) AS count
             ORDER BY
                 node_id, rank
-        """.format(node_type) 
-        nodes = {}
-        invalid = []
-        for row in self.graph.cypher.stream(query, issue_id=issue_id):
-            if row.node_id not in nodes:
-                nodes[row.node_id] = {'name': row.name, 'data': [0, 0, 0, 0, 0]}
-            if row.rank in range(-2, 3):
-                nodes[row.node_id]["data"][row.rank + 2] = row.count
-            else:
-                invalid.append(row.rank)
+            RETURN node_id, name, collect(count) as data
+        """.format(node_type)
+        nodes = {row.node_id: {'name': row.name, 'data': row.data}
+                 for row in self.graph.cypher.stream(query, issue_id=issue_id)}
+        invalid_query = """
+        MATCH (:User)-[r:RANKS]-(:`{0}`)<-[:HAS]-(i:Issue)
+        WHERE i.node_id = {{issue_id}}
+        AND (r.rank < -2 OR r.rank > 2)
+        RETURN r.rank as rank
+        """.format(node_type)
+        invalid = [row.rank for row in
+                   self.graph.cypher.stream(invalid_query, issue_id=issue_id)]
         return True, nodes, invalid


### PR DESCRIPTION
Re-committing that reverted performance improvement, but run with `OPTIONAL MATCH` and a list of valid ranks, so it gives a `0` count when summarizing a rank that's not used.
